### PR TITLE
update text to clarify limits of services on particular islands

### DIFF
--- a/www/cobrands/makemyisland/templates/en/initial_help.html
+++ b/www/cobrands/makemyisland/templates/en/initial_help.html
@@ -3,12 +3,12 @@
 <p>Using this app you can report problems such as:</p>
 <p>
     <ul>
-        <li>dumping garbage on public areas (All islands).</li>
-        <li>Broken public street lights( For only in Laamu Atoll).</li>
-        <li>Erosion of the beaches ( For only in Laamu Atoll).</li>
-        <li>Damage to public property ( For only in Laamu Atoll).</li>
-        <li>Graffiti ( For only in Laamu Atoll).</li>
-        <li>Improper parking along the main road ( For only in Laamu Atoll).</li>
+        <li>dumping garbage on public areas (Male' Villimale' Hulhumale' and the 4 island stretch of Laamu Atolls).</li>
+        <li>Broken public street lights (Laamu Atoll only).</li>
+        <li>Erosion of the beaches (Laamu Atoll only).</li>
+        <li>Damage to public property (Laamu Atoll only).</li>
+        <li>Graffiti (for the 4 island stretch of Laamu atoll: Maandhoo, Kahdhoo, Gan and Fonadhoo).</li>
+        <li>Improper parking along the main road (Laamu Atoll only).</li>
     </ul>
 </p>
 


### PR DESCRIPTION
Changing the intro text to clarify which islands are and are not covered.

Note I haven't build this to check the layout is OK (hence pull request for a dev with Android SDK already set up to check ;-) )

closes #208