### PR TITLE
do not skip extra details screen if body unresponsive

### DIFF
--- a/www/js/views/details.js
+++ b/www/js/views/details.js
@@ -108,7 +108,7 @@
                                         return accumulator && (field.automated === "hidden_field");
                                     }, true);
 
-                                    if (all_hidden) {
+                                    if (all_hidden && data.unresponsive === '') {
                                         that.navigate( that.next );
                                     } else {
                                         that.model.set('category_extras', data.category_extra);


### PR DESCRIPTION
Explicitly check if the body is unresponsive before skipping the extra
details screen.

Fixes #266