### PR TITLE
Improvements to stopper/unresponsive handling

### DIFF
--- a/templates/details.html
+++ b/templates/details.html
@@ -6,17 +6,19 @@
 <div data-role="content">
     <div class="gmailstyletest">
         <div>
+            <%= categories_html %>
+        </div>
+
+        <div class="form-enabled">
             <label for="form_title">[% loc('Subject') %]</label>
             <input data-role="none" type="text" name="title" id="form_title" placeholder="[% loc('Provide a title') %]" value="<%= title %>" required>
         </div>
 
-        <div>
-            <%= categories %>
-        </div>
-
-        <div class="noborder">
+        <div class="noborder form-enabled">
             <label for="form_detail">[% loc('Details') %]</label>
             <textarea data-role="none" name="detail" id="form_detail" placeholder="[% loc('Please fill in details of the problem.') %]" required><%= details %></textarea>
         </div>
+
+        <div class="form-disabled" id="form-disabled-message"></div>
     </div>
 </div>

--- a/templates/details_extra.html
+++ b/templates/details_extra.html
@@ -7,6 +7,14 @@
             <a id="next" data-icon="arrow-r" data-iconpos="right" class="ui-btn-right">[% loc('Next') %]</a>
         <% } %>
 </div>
-<div data-role="content" data-enhance="false">
-    <%= category_extras %>
+<div data-role="content">
+    <div id="form-disabled-banner">
+        <div id="form-disabled-message"></div>
+        <div id="start-new-report-wrapper">
+            <a data-role="button" id="start-new-report" data-theme="a">[% loc('Start new report') %]</a>
+        </div>
+    </div>
+    <div data-enhance="false">
+        <%= category_extras_html %>
+    </div>
 </div>

--- a/templates/top_message.html
+++ b/templates/top_message.html
@@ -1,0 +1,8 @@
+<div data-role="header">
+    <a data-rel="back" data-icon="arrow-l" class="ui-btn-left">[% loc('Back') %]</a>
+    <a id="next" data-icon="arrow-r" data-iconpos="right" class="ui-btn-right">[% loc('Next') %]</a>
+    <h1></h1>
+</div>
+<div data-role="content" data-enhance="false" id="top_message_wrapper">
+    <%= top_message %>
+</div>

--- a/www/css/fms.css
+++ b/www/css/fms.css
@@ -1026,23 +1026,28 @@
         visibility: hidden;
     }
 
-/* iPhone X has an 'unsafe' area occupied by the home
+/* Some iOS devices have an 'unsafe' area occupied by the home
 indicator at the bottom of screen, which we need to stop UI controls
 clashing with. */
-body.iphone-x {
-    /* iOS 11–11.1 use constant(), 11.2 uses env() - assign whatever one is valid
+body.ios {
+    /* iOS 11–11.1 use constant(), 11.2– use env() - assign whatever one is valid
        to a CSS variable as this makes things simpler (e.g. with calc()) */
     --safe-area-inset-bottom: constant(safe-area-inset-bottom);
     --safe-area-inset-bottom: env(safe-area-inset-bottom);
 }
 
 /* The OpenLayers attribution control */
-body.iphone-x .olControlAttribution {
+body.ios .olControlAttribution {
     padding-bottom: var(--safe-area-inset-bottom);
 }
 
 /* The "new report here" button  */
-body.iphone-x .map-bottom-btn {
+body.ios .map-bottom-btn {
     /* Can't use env() inside calc(), so assign value to a CSS variable instead */
     bottom: calc(20px + var(--safe-area-inset-bottom));
+}
+
+body.ios #reposition {
+    /* Can't use env() inside calc(), so assign value to a CSS variable instead */
+    bottom: calc(65px + var(--safe-area-inset-bottom));
 }

--- a/www/css/fms.css
+++ b/www/css/fms.css
@@ -861,6 +861,14 @@
         margin-bottom: 0px;
     }
 
+    #details-page .form-disabled {
+        display: none;
+    }
+
+    #form-disabled-message {
+        padding: 1em;
+    }
+
 /* open311 extra fields screen */
 
     #details-extra-page div[data-role="content"] {

--- a/www/css/fms.css
+++ b/www/css/fms.css
@@ -901,6 +901,18 @@
         padding-top: 0.5em;
     }
 
+    #details-extra-page #form-disabled-banner {
+        display: none;
+        margin: -15px -15px 0;
+        background-color: rgba(255, 241, 179, 0.97);
+    }
+
+    #details-extra-page #start-new-report-wrapper {
+        display: none;
+        padding: 1em;
+    }
+
+
 /* submission pages */
 
     #errors {

--- a/www/css/fms.css
+++ b/www/css/fms.css
@@ -747,6 +747,17 @@
         margin-left: 5px;
     }
 
+/* top message (aka unresponsive) screen */
+
+    #top_message_wrapper {
+        padding: 1em;
+    }
+
+    #top_message_wrapper h1 {
+        margin-top: 0;
+        line-height: 100%;
+    }
+
 /* photo screen */
     div.photo {
         position: relative;

--- a/www/index.html
+++ b/www/index.html
@@ -84,6 +84,7 @@
         <script type="text/javascript" src="js/views/around.js"></script>
         <script type="text/javascript" src="js/views/search.js"></script>
         <script type="text/javascript" src="js/views/existing.js"></script>
+        <script type="text/javascript" src="js/views/top_message.js"></script>
         <script type="text/javascript" src="js/views/photo.js"></script>
         <script type="text/javascript" src="js/views/details.js"></script>
         <script type="text/javascript" src="js/views/details_extra.js"></script>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -279,12 +279,6 @@ var tpl = {
             }
             $('#load-screen').height( $(window).height() );
 
-            // Rough-and-ready iPhone X detection so CSS can stop things
-            // obscuring the home indicator at the bottom of the screen.
-            if (window.screen.width == 375 && window.screen.height == 812) {
-                $("body").addClass("iphone-x");
-            }
-
             FMS.initialized = 1;
             if ( navigator && navigator.splashscreen ) {
                 navigator.splashscreen.hide();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -163,12 +163,14 @@ var tpl = {
 
         removeDraft: function(draftID, removePhoto) {
             var draft = FMS.allDrafts.get(draftID);
-            var files = draft.get('files');
-            FMS.allDrafts.remove(draft);
-            draft.destroy();
+            if (draft) {
+                var files = draft.get('files');
+                FMS.allDrafts.remove(draft);
+                draft.destroy();
 
-            if ( removePhoto && files.length ) {
-                return FMS.files.deleteURIs( files );
+                if ( removePhoto && files.length ) {
+                    return FMS.files.deleteURIs( files );
+                }
             }
             var p = $.Deferred();
             p.resolve();

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -69,7 +69,7 @@ var tpl = {
 (function (FMS, Backbone, _, $) {
     _.extend(FMS, {
         templates: [
-            'home', 'help', 'initial_help', 'around', 'offline', 'save_offline', 'reports', 'login', 'address_search', 'existing', 'photo', 'details', 'details_extra', 'submit', 'submit_email', 'submit_name', 'submit_set_password', 'submit_password', 'submit_confirm', 'sent'
+            'home', 'help', 'initial_help', 'around', 'offline', 'save_offline', 'reports', 'login', 'address_search', 'existing', 'top_message', 'photo', 'details', 'details_extra', 'submit', 'submit_email', 'submit_name', 'submit_set_password', 'submit_password', 'submit_confirm', 'sent'
         ],
 
         usedBefore: 0,

--- a/www/js/router.js
+++ b/www/js/router.js
@@ -11,6 +11,7 @@
                 'around': 'around',
                 'search': 'search',
                 'existing': 'existing',
+                'top_message': 'top_message',
                 'photo': 'photo',
                 'details': 'details',
                 'details_extra': 'details_extra',
@@ -69,6 +70,11 @@
             offline: function() {
                 var offlineView = new FMS.OfflineView({ model: FMS.currentDraft });
                 this.changeView(offlineView);
+            },
+
+            top_message: function(){
+                var topMessageView = new FMS.TopMessageView({ model: FMS.currentDraft });
+                this.changeView(topMessageView);
             },
 
             photo: function(){

--- a/www/js/views/around.js
+++ b/www/js/views/around.js
@@ -319,7 +319,7 @@
                     FMS.saveCurrentDraft();
                     this.navigate( 'offline' );
                 } else {
-                    this.listenTo(FMS.locator, 'gps_located', this.goPhoto);
+                    this.listenTo(FMS.locator, 'gps_located', this.startReport);
                     this.listenTo(FMS.locator, 'gps_failed', this.locationCheckFailed );
                     FMS.locator.check_location( { latitude: position.lat, longitude: position.lon } );
                 }
@@ -418,7 +418,7 @@
                 }
             },
 
-            goPhoto: function(info) {
+            startReport: function(info) {
                 this.pauseMap();
                 this.model.set('lat', info.coordinates.latitude );
                 this.model.set('lon', info.coordinates.longitude );
@@ -429,7 +429,21 @@
                 }
                 FMS.saveCurrentDraft();
 
+                if (info.details.top_message) {
+                    this.model.set('top_message', info.details.top_message);
+                    this.goTopMessage();
+                } else {
+                    this.model.unset('top_message');
+                    this.goPhoto();
+                }
+            },
+
+            goPhoto: function(info) {
                 this.navigate( 'photo' );
+            },
+
+            goTopMessage: function() {
+                this.navigate( 'top_message' );
             },
 
             locationCheckFailed: function() {

--- a/www/js/views/around.js
+++ b/www/js/views/around.js
@@ -422,7 +422,8 @@
                 this.pauseMap();
                 this.model.set('lat', info.coordinates.latitude );
                 this.model.set('lon', info.coordinates.longitude );
-                this.model.set('categories', info.details.category );
+                this.model.set('categories_html', info.details.category );
+                this.model.set('categories', info.details.by_category );
                 if ( info.details.titles_list ) {
                     this.model.set('titles_list', info.details.titles_list);
                 }

--- a/www/js/views/around.js
+++ b/www/js/views/around.js
@@ -273,6 +273,7 @@
                 fixmystreet.bbox_strategy.update({force: true});
                 if ( this.model.isPartial() ) {
                     FMS.clearCurrentDraft();
+                    this.model = FMS.currentDraft;
                 } else {
                     // it's not partial but we've created a draft anyway so
                     // delete it
@@ -283,6 +284,7 @@
                     }
                     this.model.set('lat', null);
                     this.model.set('lon', null);
+                    this.model.id = undefined;
                 }
                 this.displayButtons(false);
             },

--- a/www/js/views/details.js
+++ b/www/js/views/details.js
@@ -100,7 +100,12 @@
                             if (all_hidden && !category.unresponsive) {
                                 this.navigate( this.next );
                             } else {
-                                this.model.set('category_extras', category.category_extra);
+                                this.model.set('category_extras_html', category.category_extra);
+                                var extras = {};
+                                $.each(category.category_extra_json, function(i, extra) {
+                                    extras[extra.code] = extra;
+                                });
+                                this.model.set('category_extras', extras);
                                 this.navigate('details_extra');
                             }
                         } else {

--- a/www/js/views/details.js
+++ b/www/js/views/details.js
@@ -35,7 +35,7 @@
                     this.$('#form_category').val( this.model.get('category') );
                 }
                 this.setSelectClass();
-
+                this.checkForDisabledForm();
             },
 
             beforeDisplay: function(extra) {
@@ -154,6 +154,51 @@
             updateSelect: function() {
                 this.updateCurrentReport();
                 this.setSelectClass();
+                this.checkForDisabledForm();
+            },
+
+            checkForDisabledForm: function() {
+                var categories = this.model.get('categories');
+                var category = categories[this.$('#form_category').val()];
+
+                if (category && category.disable_form && category.disable_form.all) {
+                    this.disableForm(category.disable_form.all);
+                } else {
+                    this.enableForm();
+                }
+            },
+
+            enableForm: function() {
+                this.$(".form-enabled").show();
+                this.$(".form-disabled").hide();
+                this.$("#next").show();
+                this.$("#form-disabled-message").empty();
+            },
+
+            disableForm: function(message) {
+                this.$(".form-disabled").show();
+                this.$(".form-enabled").hide();
+                this.$("#next").hide();
+                this.$("#form-disabled-message").html(message);
+                // If there are any links in the message, e.g. a
+                // "use this other service" link, then they need to be
+                // handled correctly by calling FMS.openExternal
+                // otherwise tapping them doesn't do anything at all.
+                var that = this;
+                this.$("#form-disabled-message a").click(function(e) {
+                    FMS.openExternal(e.originalEvent);
+                    FMS.removeDraft(that.model.id, true).done(
+                        function() { that.onDraftRemove(); }
+                    ).fail(
+                        function() { that.onDraftRemove(); }
+                    );
+                    return false;
+                }).attr('data-role', 'none');
+            },
+
+            onDraftRemove: function() {
+                FMS.clearCurrentDraft();
+                this.navigate( 'around', 'left' );
             },
 
             updateCurrentReport: function() {

--- a/www/js/views/details.js
+++ b/www/js/views/details.js
@@ -89,39 +89,23 @@
                     if ( FMS.isOffline ) {
                         this.navigate( 'save_offline' );
                     } else {
-                        var that = this;
-                        $.ajax( {
-                            url: CONFIG.FMS_URL + '/report/new/category_extras',
-                            type: 'POST',
-                            data: {
-                                category: this.model.get('category'),
-                                latitude: this.model.get('lat'),
-                                longitude: this.model.get('lon')
-                            },
-                            dataType: 'json',
-                            timeout: 30000,
-                            success: function( data, status ) {
-                                if ( data && data.category_extra && data.category_extra.length > 0 ) {
-                                    // Some categories have only hidden fields - in that case we
-                                    // don't want to navigate to the details_extra view.
-                                    var all_hidden = data.category_extra_json.reduce(function(accumulator, field) {
-                                        return accumulator && (field.automated === "hidden_field");
-                                    }, true);
+                        var category = this.model.get('categories')[this.model.get('category')];
+                        if ( category && category.category_extra && category.category_extra.length > 0 ) {
+                            // Some categories have only hidden fields - in that case we
+                            // don't want to navigate to the details_extra view.
+                            var all_hidden = category.category_extra_json.reduce(function(accumulator, field) {
+                                return accumulator && (field.automated === "hidden_field");
+                            }, true);
 
-                                    if (all_hidden && !data.unresponsive) {
-                                        that.navigate( that.next );
-                                    } else {
-                                        that.model.set('category_extras', data.category_extra);
-                                        that.navigate('details_extra');
-                                    }
-                                } else {
-                                    that.navigate( that.next );
-                                }
-                            },
-                            error: function() {
-                                that.displayAlert(FMS.strings.category_extra_check_error);
+                            if (all_hidden && !category.unresponsive) {
+                                this.navigate( this.next );
+                            } else {
+                                this.model.set('category_extras', category.category_extra);
+                                this.navigate('details_extra');
                             }
-                        } );
+                        } else {
+                            this.navigate( this.next );
+                        }
                     }
                 }
             },

--- a/www/js/views/details_extra.js
+++ b/www/js/views/details_extra.js
@@ -20,6 +20,14 @@
             afterRender: function() {
                 this.populateFields();
                 this.enableScrolling();
+                // If there are any links in the category extra, e.g. a
+                // "use this other service" link, then they need to be
+                // handled correctly by calling FMS.openExternal
+                // otherwise tapping them doesn't do anything at all.
+                this.$("#category_meta a").click(function(e) {
+                    FMS.openExternal(e.originalEvent);
+                    return false;
+                });
             },
 
             onClickButtonPrev: function(e) {

--- a/www/js/views/fms.js
+++ b/www/js/views/fms.js
@@ -48,17 +48,19 @@
             fixPageHeight: function(extra) {
                 extra = extra || 0;
                 var header = this.$("div[data-role='header']:visible"),
-                content = this.$(this.contentSelector),
-                top = content.position().top,
-                viewHeight = $(window).height(),
-                contentHeight = FMS.windowHeight - header.outerHeight() - this.bottomMargin - extra;
+                    content = this.$(this.contentSelector);
+                var top = content.position().top,
+                    viewHeight = $(window).height(),
+                    contentHeight = FMS.windowHeight - header.outerHeight() - this.bottomMargin - extra;
 
-                if ($("body").hasClass("iphone-x")) {
+                if ($("body").hasClass("ios")) {
                     var body = $("body").get(0);
                     var inset = window.getComputedStyle(body).getPropertyValue("--safe-area-inset-bottom");
                     // We want the pixel value, not the CSS string
                     inset = parseInt(inset.replace(/[^\d]*/g, ''));
-                    contentHeight -= inset;
+                    if (!isNaN(inset)) {
+                        contentHeight -= inset;
+                    }
                 }
 
                 this.setHeight( content, contentHeight - top );

--- a/www/js/views/photo.js
+++ b/www/js/views/photo.js
@@ -59,13 +59,30 @@
                 var options = this.getCameraOptions(isFromAlbum);
                 navigator.camera.getPicture(
                     function(imgURI) {
+                        that.fixiOSStatusBar();
                         that.getPhotoSuccess(imgURI);
                     },
                     function(error) {
+                        that.fixiOSStatusBar();
                         that.getPhotoFail(error);
                     },
                     options
                 );
+            },
+
+            fixiOSStatusBar: function() {
+                // iOS 13 suffers a bug where the status bar height isn't correctly
+                // set after a full-screen overlay (e.g. the photo picker or camera)
+                // is presented. This results in the containing webview being scrolled
+                // up slightly, chopping off the top of the app UI and preventing
+                // the user from proceeding past the photo screen.
+                // This bug should be fixed in either cordova-plugin-camera or
+                // cordova-plugin-statusbar, but until then this workaround
+                // of hiding and showing the status bar fixes the problem.
+                if (device && device.platform === 'iOS' && parseInt(device.version) >= 13) {
+                    StatusBar.hide();
+                    StatusBar.show();
+                }
             },
 
             getCameraOptions: function(isFromAlbum) {

--- a/www/js/views/photo.js
+++ b/www/js/views/photo.js
@@ -17,6 +17,15 @@
                 'vclick .del_photo_button': 'deletePhoto'
             },
 
+            onClickButtonPrev: function(e) {
+                e.preventDefault();
+                if (this.model.get('top_message')) {
+                    this.navigate( 'top_message', true );
+                } else {
+                    this.navigate( this.prev, true );
+                }
+            },
+
             beforeDisplay: function() {
                 this.fixPageHeight();
             },

--- a/www/js/views/top_message.js
+++ b/www/js/views/top_message.js
@@ -1,0 +1,25 @@
+(function (FMS, Backbone, _, $) {
+    _.extend( FMS, {
+        TopMessageView: FMS.FMSView.extend({
+            template: 'top_message',
+            id: 'top_message-page',
+            prev: 'around',
+            next: 'photo',
+
+            events: {
+                'pagehide': 'destroy',
+                'pagebeforeshow': 'beforeDisplay',
+                'pageshow': 'afterDisplay',
+                'vclick .ui-btn-left': 'onClickButtonPrev',
+                'vclick .ui-btn-right': 'onClickButtonNext',
+            },
+
+            afterRender: function() {
+                this.$("#top_message_wrapper a").click(function(e) {
+                    FMS.openExternal(e.originalEvent);
+                    return false;
+                });
+            },
+        })
+    });
+})(FMS, Backbone, _, $);

--- a/www/templates/en/details.html
+++ b/www/templates/en/details.html
@@ -6,17 +6,19 @@
 <div data-role="content">
     <div class="gmailstyletest">
         <div>
+            <%= categories_html %>
+        </div>
+
+        <div class="form-enabled">
             <label for="form_title">Subject</label>
             <input data-role="none" type="text" name="title" id="form_title" placeholder="Provide a title" value="<%= title %>" required>
         </div>
 
-        <div>
-            <%= categories %>
-        </div>
-
-        <div class="noborder">
+        <div class="noborder form-enabled">
             <label for="form_detail">Details</label>
             <textarea data-role="none" name="detail" id="form_detail" placeholder="Please fill in details of the problem." required><%= details %></textarea>
         </div>
+
+        <div class="form-disabled" id="form-disabled-message"></div>
     </div>
 </div>

--- a/www/templates/en/details_extra.html
+++ b/www/templates/en/details_extra.html
@@ -7,6 +7,14 @@
             <a id="next" data-icon="arrow-r" data-iconpos="right" class="ui-btn-right">Next</a>
         <% } %>
 </div>
-<div data-role="content" data-enhance="false">
-    <%= category_extras %>
+<div data-role="content">
+    <div id="form-disabled-banner">
+        <div id="form-disabled-message"></div>
+        <div id="start-new-report-wrapper">
+            <a data-role="button" id="start-new-report" data-theme="a">Start new report</a>
+        </div>
+    </div>
+    <div data-enhance="false">
+        <%= category_extras_html %>
+    </div>
 </div>

--- a/www/templates/en/top_message.html
+++ b/www/templates/en/top_message.html
@@ -1,0 +1,8 @@
+<div data-role="header">
+    <a data-rel="back" data-icon="arrow-l" class="ui-btn-left">Back</a>
+    <a id="next" data-icon="arrow-r" data-iconpos="right" class="ui-btn-right">Next</a>
+    <h1></h1>
+</div>
+<div data-role="content" data-enhance="false" id="top_message_wrapper">
+    <%= top_message %>
+</div>


### PR DESCRIPTION
Some improvements to the reporting flow for situations where a report is for an unresponsive council or a category which has disabled reports entirely.

## Disabling the report form

Prevents a report being made if the entire category has a stopper:

![disabled_category](https://user-images.githubusercontent.com/4776/65042039-eb9ba280-d94f-11e9-86ed-f374e70a0fd6.gif)

(note upon returning to the app the user has been taken back to the map screen)

Also supports disabling the form as a result of a category extra field:

![field_message](https://user-images.githubusercontent.com/4776/65042113-171e8d00-d950-11e9-885a-72c337809393.gif)

When the user returns to the app the report hasn't been removed, as the user may have entered a fair bit of information by that point. Instead a new button has appeared allowing them to get back to the map screen. Alternatively they can change their inputs or go to the previous screen to edit their report.

![show_button](https://user-images.githubusercontent.com/4776/65042218-4d5c0c80-d950-11e9-8d73-037e4514eea1.gif)

## Unresponsive councils

Shows a message to user before they enter any report content:

![unresponsive](https://user-images.githubusercontent.com/4776/65785243-db53a680-e14b-11e9-920d-ec5ba1365682.gif)

Fixes #245.
Fixes #277.
Fixes #278.
Fixes #281.