### PR TITLE
Always send email/password when checking auth or making report

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -120,14 +120,21 @@ var tpl = {
         checkLoggedInStatus: function() {
             var p = $.Deferred();
 
-            if ( FMS.isOffline ) {
+            var data = {};
+            if (FMS.currentUser) {
+                data.username = FMS.currentUser.get("email");
+                data.password_sign_in = FMS.currentUser.get("password");
+            }
+
+            if ( FMS.isOffline || !data ) {
                 p.resolve();
             } else {
                 $.ajax( {
                     url: CONFIG.FMS_URL + '/auth/ajax/check_auth',
-                    type: 'GET',
+                    type: 'POST',
                     dataType: 'json',
                     timeout: 30000,
+                    data: data,
                 })
                 .done(function() {
                     FMS.isLoggedIn = 1;

--- a/www/js/models/report.js
+++ b/www/js/models/report.js
@@ -146,8 +146,8 @@
                     }
                 }
 
-                if ( model.get('submit_clicked') == 'submit_sign_in' ) {
-                    params.submit_sign_in = 1;
+                if ( model.get('submit_clicked') == 'submit_sign_in' || FMS.isLoggedIn ) {
+                    params.submit_sign_in = FMS.isLoggedIn ? 2 : 1;
                     params.password_sign_in = model.get('user').get('password');
                     params.remember_me = 1;
                 } else {


### PR DESCRIPTION
iOS app can’t send cookies so send the user’s auth info instead.

Fixes #300 